### PR TITLE
Use default consumer configuration when configuration is nil

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -34,7 +34,7 @@ type MessageConsumer struct {
 
 func NewConsumer(zookeeperConnectionString string, consumerGroup string, topics []string, config *consumergroup.Config) (Consumer, error) {
 
-	if config != nil {
+	if config == nil {
 		config = DefaultConsumerConfig()
 	}
 


### PR DESCRIPTION
I think that default configuration has to be used when no configuration is provided.