### PR TITLE
Added possibility to forward errors

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -34,6 +34,7 @@ type MessageConsumer struct {
 	zookeeperNodes []string
 	consumer       ConsumerGrouper
 	config         *consumergroup.Config
+	errCh          chan error
 }
 
 type perseverantConsumer struct {
@@ -46,33 +47,51 @@ type perseverantConsumer struct {
 	retryInterval             time.Duration
 }
 
-func NewConsumer(zookeeperConnectionString string, consumerGroup string, topics []string, config *consumergroup.Config) (Consumer, error) {
-	zookeeperNodes, chroot := kazoo.ParseConnectionString(zookeeperConnectionString)
+type Config struct {
+	ZookeeperConnectionString string
+	ConsumerGroup             string
+	Topics                    []string
+	ConsumerGroupConfig       *consumergroup.Config
+	Err                       chan error
+}
 
-	if config == nil {
-		config = DefaultConsumerConfig()
-		config.Zookeeper.Chroot = chroot
-	} else if config.Zookeeper.Chroot != chroot {
+func NewConsumer(config Config) (Consumer, error) {
+	zookeeperNodes, chroot := kazoo.ParseConnectionString(config.ZookeeperConnectionString)
+
+	if config.ConsumerGroupConfig == nil {
+		config.ConsumerGroupConfig = DefaultConsumerConfig()
+		config.ConsumerGroupConfig.Zookeeper.Chroot = chroot
+	} else if config.ConsumerGroupConfig.Zookeeper.Chroot != chroot {
 		log.WithFields(log.Fields{
 			"method":           "NewConsumer",
-			"configuredChroot": config.Zookeeper.Chroot,
+			"configuredChroot": config.ConsumerGroupConfig.Zookeeper.Chroot,
 			"parsedChroot":     chroot,
 		}).Error("Mismatch in Zookeeper config while creating Kafka consumer")
 		return nil, errors.New("Mismatch in Zookeeper config while creating Kafka consumer")
 	}
 
-	consumer, err := consumergroup.JoinConsumerGroup(consumerGroup, topics, zookeeperNodes, config)
+	consumer, err := consumergroup.JoinConsumerGroup(config.ConsumerGroup, config.Topics, zookeeperNodes, config.ConsumerGroupConfig)
 	if err != nil {
 		log.WithError(err).WithField("method", "NewConsumer").Error("Error creating Kafka consumer")
 		return nil, err
 	}
 
+	if config.Err == nil {
+		config.Err = make(chan error, 2)
+		go func() {
+			for range config.Err {
+				//just ignore
+			}
+		}()
+	}
+
 	return &MessageConsumer{
-		topics:         topics,
-		consumerGroup:  consumerGroup,
+		topics:         config.Topics,
+		consumerGroup:  config.ConsumerGroup,
 		zookeeperNodes: zookeeperNodes,
 		consumer:       consumer,
-		config:         config,
+		config:         config.ConsumerGroupConfig,
+		errCh:          config.Err,
 	}, nil
 }
 
@@ -85,6 +104,7 @@ func (c *MessageConsumer) StartListening(messageHandler func(message FTMessage) 
 	go func() {
 		for err := range c.consumer.Errors() {
 			log.WithError(err).WithField("method", "StartListening").Error("Error proccessing message")
+			c.errCh <- err
 		}
 	}()
 
@@ -93,10 +113,12 @@ func (c *MessageConsumer) StartListening(messageHandler func(message FTMessage) 
 			ftMsg, err := rawToFTMessage(message.Value)
 			if err != nil {
 				log.WithError(err).WithField("method", "StartListening").Error("Error converting Kafka message body to FTMessage")
+				c.errCh <- err
 			}
 			err = messageHandler(ftMsg)
 			if err != nil {
 				log.WithError(err).WithField("method", "StartListening").WithField("messageKey", message.Key).Error("Error processing message")
+				c.errCh <- err
 			}
 			c.consumer.CommitUpto(message)
 		}
@@ -106,13 +128,23 @@ func (c *MessageConsumer) StartListening(messageHandler func(message FTMessage) 
 func (c *MessageConsumer) Shutdown() {
 	if err := c.consumer.Close(); err != nil {
 		log.WithError(err).WithField("method", "Shutdown").Error("Error closing the consumer")
+		c.errCh <- err
+
 	}
+	close(c.errCh)
 }
 
 func (c *MessageConsumer) ConnectivityCheck() error {
 	// establishing (or failing to establish) a new connection (with a distinct consumer group) is a reasonable check
 	// as experiment shows the consumer's existing connection is automatically repaired after any interruption
-	healthcheckConsumer, err := NewConsumer(strings.Join(c.zookeeperNodes, ","), c.consumerGroup+"-healthcheck", c.topics, c.config)
+	config := Config{
+		ZookeeperConnectionString: strings.Join(c.zookeeperNodes, ","),
+		ConsumerGroup:             c.consumerGroup + "-healthcheck",
+		Topics:                    c.topics,
+		ConsumerGroupConfig:       c.config,
+		Err:                       c.errCh,
+	}
+	healthcheckConsumer, err := NewConsumer(config)
 	if err != nil {
 		return err
 	}
@@ -124,7 +156,12 @@ func (c *MessageConsumer) ConnectivityCheck() error {
 func (c *perseverantConsumer) connect() {
 	connectorLog := log.WithField("zookeeper", c.zookeeperConnectionString).WithField("topics", c.topics).WithField("consumerGroup", c.consumerGroup)
 	for {
-		consumer, err := NewConsumer(c.zookeeperConnectionString, c.consumerGroup, c.topics, c.config)
+		consumer, err := NewConsumer(Config{
+			ZookeeperConnectionString: c.zookeeperConnectionString,
+			ConsumerGroup:             c.consumerGroup,
+			Topics:                    c.topics,
+			ConsumerGroupConfig:       c.config,
+		})
 		if err == nil {
 			connectorLog.Info("connected to Kafka consumer")
 			c.setConsumer(consumer)

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -103,14 +103,8 @@ func (c *MessageConsumer) StartListening(messageHandler func(message FTMessage) 
 
 	go func() {
 		for message := range c.consumer.Messages() {
-			ftMsg, err := rawToFTMessage(message.Value)
-			if err != nil {
-				log.WithError(err).WithField("method", "StartListening").Error("Error converting Kafka message body to FTMessage")
-				if c.errCh != nil {
-					c.errCh <- err
-				}
-			}
-			err = messageHandler(ftMsg)
+			ftMsg := rawToFTMessage(message.Value)
+			err := messageHandler(ftMsg)
 			if err != nil {
 				log.WithError(err).WithField("method", "StartListening").WithField("messageKey", message.Key).Error("Error processing message")
 				if c.errCh != nil {

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -142,7 +142,6 @@ func (c *MessageConsumer) ConnectivityCheck() error {
 		ConsumerGroup:             c.consumerGroup + "-healthcheck",
 		Topics:                    c.topics,
 		ConsumerGroupConfig:       c.config,
-		Err:                       c.errCh,
 	}
 	healthcheckConsumer, err := NewConsumer(config)
 	if err != nil {

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -26,7 +26,12 @@ func TestNewConsumer(t *testing.T) {
 	config.Offsets.Initial = sarama.OffsetNewest
 	config.Offsets.ProcessingTimeout = 10 * time.Second
 
-	consumer, err := NewConsumer(zookeeperConnectionString, testConsumerGroup, []string{testTopic}, config)
+	consumer, err := NewConsumer(Config{
+		ZookeeperConnectionString: zookeeperConnectionString,
+		ConsumerGroup:             testConsumerGroup,
+		Topics:                    []string{testTopic},
+		ConsumerGroupConfig:       config,
+	})
 	assert.NoError(t, err)
 
 	err = consumer.ConnectivityCheck()
@@ -57,7 +62,7 @@ func TestNewPerseverantConsumer(t *testing.T) {
 	err = consumer.ConnectivityCheck()
 	assert.EqualError(t, err, errConsumerNotConnected)
 
-	consumer.StartListening(func(msg FTMessage) error {return nil})
+	consumer.StartListening(func(msg FTMessage) error { return nil })
 
 	err = consumer.ConnectivityCheck()
 	assert.NoError(t, err)

--- a/kafka/ftmessage.go
+++ b/kafka/ftmessage.go
@@ -36,17 +36,14 @@ func (m *FTMessage) Build() string {
 	return buffer.String()
 }
 
-func rawToFTMessage(msg []byte) (FTMessage, error) {
-	var err error
+func rawToFTMessage(msg []byte) (FTMessage) {
 	ftMsg := FTMessage{}
 	raw := string(msg)
 
 	doubleNewLineStartIndex := getHeaderSectionEndingIndex(string(raw[:]))
-	if ftMsg.Headers, err = parseHeaders(string(raw[:doubleNewLineStartIndex])); err != nil {
-		return ftMsg, err
-	}
+	ftMsg.Headers = parseHeaders(string(raw[:doubleNewLineStartIndex]));
 	ftMsg.Body = strings.TrimSpace(string(raw[doubleNewLineStartIndex:]))
-	return ftMsg, nil
+	return ftMsg
 }
 
 var re = regexp.MustCompile("[\\w-]*:[\\w\\-:/. ]*")
@@ -68,7 +65,7 @@ func getHeaderSectionEndingIndex(msg string) int {
 	return len(msg)
 }
 
-func parseHeaders(msg string) (map[string]string, error) {
+func parseHeaders(msg string) (map[string]string) {
 	headerLines := re.FindAllString(msg, -1)
 
 	headers := make(map[string]string)
@@ -76,7 +73,7 @@ func parseHeaders(msg string) (map[string]string, error) {
 		key, value := parseHeader(line)
 		headers[key] = value
 	}
-	return headers, nil
+	return headers
 }
 func parseHeader(header string) (string, string) {
 	key := kre.FindString(header)

--- a/kafka/ftmessage_test.go
+++ b/kafka/ftmessage_test.go
@@ -21,8 +21,7 @@ func Test_FTMessage_Build(t *testing.T) {
 
 func TestFTMessage_Parse(t *testing.T) {
 	payload := []byte(testFTMessage)
-	ftmsg, err := rawToFTMessage(payload)
-	assert.NoError(t, err)
+	ftmsg := rawToFTMessage(payload)
 
 	assert.EqualValues(t, ftmsg.Headers, testFTMessageHeaders)
 	assert.EqualValues(t, ftmsg.Body, testFTMessageBody)
@@ -30,8 +29,7 @@ func TestFTMessage_Parse(t *testing.T) {
 
 func TestFTMessage_Parse_NoBody(t *testing.T) {
 	payload := []byte("FTMSG/1.0\ntest: test2")
-	ftmsg, err := rawToFTMessage(payload)
-	assert.NoError(t, err)
+	ftmsg := rawToFTMessage(payload)
 
 	assert.EqualValues(t, ftmsg.Headers, testFTMessageHeaders)
 	assert.EqualValues(t, ftmsg.Body, "")
@@ -39,8 +37,7 @@ func TestFTMessage_Parse_NoBody(t *testing.T) {
 
 func TestFTMessage_Parse_CRLF(t *testing.T) {
 	payload := []byte("FTMSG/1.0\ntest: test2\r\n\r\nTest Message")
-	ftmsg, err := rawToFTMessage(payload)
-	assert.NoError(t, err)
+	ftmsg := rawToFTMessage(payload)
 
 	assert.EqualValues(t, ftmsg.Headers, testFTMessageHeaders)
 	assert.EqualValues(t, ftmsg.Body, testFTMessageBody)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -123,10 +123,10 @@
 			"revisionTime": "2016-09-27T09:30:20Z"
 		},
 		{
-			"checksumSHA1": "aEmap4x1keixP+5COzkKaJjNrLI=",
+			"checksumSHA1": "Y6m0eKbfP8H8hC/NO31WQhKcXRs=",
 			"path": "github.com/wvanbergen/kazoo-go",
-			"revision": "2da972bbd3bafbae02dcd0cb755d63c09a9a504d",
-			"revisionTime": "2017-10-10T15:41:45Z"
+			"revision": "494a179ad10a1a52daa7536a82cc215bc728c399",
+			"revisionTime": "2017-11-10T11:12:02Z"
 		},
 		{
 			"checksumSHA1": "nqWNlnMmVpt628zzvyo6Yv2CX5Q=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -123,10 +123,10 @@
 			"revisionTime": "2016-09-27T09:30:20Z"
 		},
 		{
-			"checksumSHA1": "Y6m0eKbfP8H8hC/NO31WQhKcXRs=",
+			"checksumSHA1": "aEmap4x1keixP+5COzkKaJjNrLI=",
 			"path": "github.com/wvanbergen/kazoo-go",
-			"revision": "494a179ad10a1a52daa7536a82cc215bc728c399",
-			"revisionTime": "2017-11-10T11:12:02Z"
+			"revision": "2da972bbd3bafbae02dcd0cb755d63c09a9a504d",
+			"revisionTime": "2017-10-10T15:41:45Z"
 		},
 		{
 			"checksumSHA1": "nqWNlnMmVpt628zzvyo6Yv2CX5Q=",


### PR DESCRIPTION
Changes include:

* An app could specify an error channel as a parameter for new consumer which would now receive the errors while consuming from kafka (also kept existing behavior as well)
* Updated vendoring for kazoo-go lib
* A new consumer now is created via config struct (better for extending constructor params)

~~NOTE: No tests for the new feature & some data race is detected by CircleCI _in the underlying library_~~
* added tests for the new feature, refactored existing tests a bit
* cannot reproduce the data race, tests run cleanly, both locally and on CircleCI
* removed unused `err` return value from `ftmessage#parseHeaders` and adjusted callers