### PR TITLE
Bugfix/complex header values

### DIFF
--- a/kafka/ftmessage.go
+++ b/kafka/ftmessage.go
@@ -66,9 +66,7 @@ func getHeaderSectionEndingIndex(msg string) int {
 }
 
 func parseHeaders(msg string) (map[string]string) {
-	log.Info("Parsing headers: ", msg)
 	headerLines := re.FindAllString(msg, -1)
-	log.Info("Header lines: ", headerLines)
 
 	headers := make(map[string]string)
 	for _, line := range headerLines {
@@ -78,10 +76,7 @@ func parseHeaders(msg string) (map[string]string) {
 	return headers
 }
 func parseHeader(header string) (string, string) {
-	log.Info("Parsing header: ", header)
 	key := kre.FindString(header)
-	log.Info("Key for header: ", header, " ", key)
 	value := vre.FindString(header)
-	log.Info("Value for header: ", header, " ", value)
 	return key[:len(key)-1], strings.TrimSpace(value[1:])
 }

--- a/kafka/ftmessage.go
+++ b/kafka/ftmessage.go
@@ -46,9 +46,9 @@ func rawToFTMessage(msg []byte) (FTMessage) {
 	return ftMsg
 }
 
-var re = regexp.MustCompile("[\\w-]*:[\\w\\-:/. ]*")
+var re = regexp.MustCompile("[\\w-]*:[\\w\\-:/.+;= ]*")
 var kre = regexp.MustCompile("[\\w-]*:")
-var vre = regexp.MustCompile(":[\\w-:/. ]*")
+var vre = regexp.MustCompile(":[\\w-:/.+;= ]*")
 
 func getHeaderSectionEndingIndex(msg string) int {
 	//FT msg format uses CRLF for line endings
@@ -66,7 +66,9 @@ func getHeaderSectionEndingIndex(msg string) int {
 }
 
 func parseHeaders(msg string) (map[string]string) {
+	log.Info("Parsing headers: ", msg)
 	headerLines := re.FindAllString(msg, -1)
+	log.Info("Header lines: ", headerLines)
 
 	headers := make(map[string]string)
 	for _, line := range headerLines {
@@ -76,7 +78,10 @@ func parseHeaders(msg string) (map[string]string) {
 	return headers
 }
 func parseHeader(header string) (string, string) {
+	log.Info("Parsing header: ", header)
 	key := kre.FindString(header)
+	log.Info("Key for header: ", header, " ", key)
 	value := vre.FindString(header)
+	log.Info("Value for header: ", header, " ", value)
 	return key[:len(key)-1], strings.TrimSpace(value[1:])
 }

--- a/kafka/ftmessage_test.go
+++ b/kafka/ftmessage_test.go
@@ -8,8 +8,10 @@ import (
 
 var (
 	testFTMessage        = "FTMSG/1.0\ntest: test2\n\nTest Message"
+	testComplexFTMessage        = "FTMSG/1.0\nContent-Type: application/vnd.ft-upp-article+json; version=1.0; charset=utf-8\r\n\r\nTest Message"
 	testFTMessageHeaders = map[string]string{"test": "test2"}
 	testFTMessageBody    = "Test Message"
+	testComplexFTMessageHeaders = map[string]string{"Content-Type": "application/vnd.ft-upp-article+json; version=1.0; charset=utf-8"}
 )
 
 func Test_FTMessage_Build(t *testing.T) {
@@ -40,5 +42,12 @@ func TestFTMessage_Parse_CRLF(t *testing.T) {
 	ftmsg := rawToFTMessage(payload)
 
 	assert.EqualValues(t, ftmsg.Headers, testFTMessageHeaders)
+	assert.EqualValues(t, ftmsg.Body, testFTMessageBody)
+}
+func TestFTMessageWithComplexHeaders_Parse_CRLF(t *testing.T) {
+	payload := []byte(testComplexFTMessage)
+	ftmsg := rawToFTMessage(payload)
+
+	assert.EqualValues(t, ftmsg.Headers, testComplexFTMessageHeaders)
 	assert.EqualValues(t, ftmsg.Body, testFTMessageBody)
 }


### PR DESCRIPTION
Header parsing is quite strict, especially for possible values in content-type headers. I've update the value regex to accept "+", ";" and "=" characters.

And yes, it was failing to parse the whole content-type header before the fix.