### PR TITLE
Bugfix/ftmessage format

### DIFF
--- a/kafka/ftmessage.go
+++ b/kafka/ftmessage.go
@@ -22,7 +22,7 @@ func NewFTMessage(headers map[string]string, body string) FTMessage {
 
 func (m *FTMessage) Build() string {
 	var buffer bytes.Buffer
-	buffer.WriteString("FTMSG/1.0\n")
+	buffer.WriteString("FTMSG/1.0\r\n")
 
 	for k, v := range m.Headers {
 		buffer.WriteString(k)

--- a/kafka/ftmessage.go
+++ b/kafka/ftmessage.go
@@ -28,9 +28,9 @@ func (m *FTMessage) Build() string {
 		buffer.WriteString(k)
 		buffer.WriteString(": ")
 		buffer.WriteString(v)
-		buffer.WriteString("\n")
+		buffer.WriteString("\r\n")
 	}
-	buffer.WriteString("\n")
+	buffer.WriteString("\r\n")
 	buffer.WriteString(m.Body)
 
 	return buffer.String()

--- a/kafka/ftmessage.go
+++ b/kafka/ftmessage.go
@@ -41,7 +41,7 @@ func rawToFTMessage(msg []byte) (FTMessage) {
 	raw := string(msg)
 
 	doubleNewLineStartIndex := getHeaderSectionEndingIndex(string(raw[:]))
-	ftMsg.Headers = parseHeaders(string(raw[:doubleNewLineStartIndex]));
+	ftMsg.Headers = parseHeaders(string(raw[:doubleNewLineStartIndex]))
 	ftMsg.Body = strings.TrimSpace(string(raw[doubleNewLineStartIndex:]))
 	return ftMsg
 }

--- a/kafka/ftmessage_test.go
+++ b/kafka/ftmessage_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	testFTMessage        = "FTMSG/1.0\r\ntest: test2\n\nTest Message"
+	testFTMessage        = "FTMSG/1.0\r\ntest: test2\r\n\r\nTest Message"
 	testComplexFTMessage        = "FTMSG/1.0\r\nContent-Type: application/vnd.ft-upp-article+json; version=1.0; charset=utf-8\r\n\r\nTest Message"
 	testFTMessageHeaders = map[string]string{"test": "test2"}
 	testFTMessageBody    = "Test Message"

--- a/kafka/ftmessage_test.go
+++ b/kafka/ftmessage_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	testFTMessage        = "FTMSG/1.0\ntest: test2\n\nTest Message"
+	testFTMessage        = "FTMSG/1.0\r\ntest: test2\n\nTest Message"
 	testFTMessageHeaders = map[string]string{"test": "test2"}
 	testFTMessageBody    = "Test Message"
 )
@@ -28,7 +28,7 @@ func TestFTMessage_Parse(t *testing.T) {
 }
 
 func TestFTMessage_Parse_NoBody(t *testing.T) {
-	payload := []byte("FTMSG/1.0\ntest: test2")
+	payload := []byte("FTMSG/1.0\r\ntest: test2")
 	ftmsg := rawToFTMessage(payload)
 
 	assert.EqualValues(t, ftmsg.Headers, testFTMessageHeaders)
@@ -36,7 +36,7 @@ func TestFTMessage_Parse_NoBody(t *testing.T) {
 }
 
 func TestFTMessage_Parse_CRLF(t *testing.T) {
-	payload := []byte("FTMSG/1.0\ntest: test2\r\n\r\nTest Message")
+	payload := []byte("FTMSG/1.0\r\ntest: test2\r\n\r\nTest Message")
 	ftmsg := rawToFTMessage(payload)
 
 	assert.EqualValues(t, ftmsg.Headers, testFTMessageHeaders)

--- a/kafka/ftmessage_test.go
+++ b/kafka/ftmessage_test.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	testFTMessage        = "FTMSG/1.0\r\ntest: test2\n\nTest Message"
-	testComplexFTMessage        = "FTMSG/1.0\nContent-Type: application/vnd.ft-upp-article+json; version=1.0; charset=utf-8\r\n\r\nTest Message"
+	testComplexFTMessage        = "FTMSG/1.0\r\nContent-Type: application/vnd.ft-upp-article+json; version=1.0; charset=utf-8\r\n\r\nTest Message"
 	testFTMessageHeaders = map[string]string{"test": "test2"}
 	testFTMessageBody    = "Test Message"
 	testComplexFTMessageHeaders = map[string]string{"Content-Type": "application/vnd.ft-upp-article+json; version=1.0; charset=utf-8"}


### PR DESCRIPTION
FT Java messaging compatibility fix for message version (first) line.

note: Java impl does an additional validation on the first line while Go impl skips the version section and starts parsing the message directly jumping to message headers start index.