### PR TITLE
Reset monitoring connection on broken pipe errors

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -101,7 +101,7 @@ func (c *Consumer) connect() {
 		defer wg.Done()
 
 		for {
-			consumerFetcher, topicFetcher, err := newConsumerGroupOffsetFetchers(c.config)
+			consumerFetcher, topicFetcher, err := newConsumerGroupOffsetFetchers(c.config.BrokersConnectionString)
 			if err == nil {
 				log.Info("Established Kafka offset fetcher connections")
 				monitor := newConsumerMonitor(c.config, consumerFetcher, topicFetcher, c.topics, c.logger)
@@ -262,11 +262,11 @@ func newConsumerGroup(config ConsumerConfig) (sarama.ConsumerGroup, error) {
 	return sarama.NewConsumerGroup(brokers, config.ConsumerGroup, config.Options)
 }
 
-func newConsumerGroupOffsetFetchers(config ConsumerConfig) (consumerOffsetFetcher, topicOffsetFetcher, error) {
+func newConsumerGroupOffsetFetchers(brokerConnectionString string) (consumerOffsetFetcher, topicOffsetFetcher, error) {
 	options := sarama.NewConfig()
 	options.Version = sarama.V2_8_1_0
 
-	brokers := strings.Split(config.BrokersConnectionString, ",")
+	brokers := strings.Split(brokerConnectionString, ",")
 	client, err := sarama.NewClient(brokers, options)
 	if err != nil {
 		return nil, nil, err

--- a/consumer_monitor.go
+++ b/consumer_monitor.go
@@ -126,35 +126,49 @@ func (m *consumerMonitor) run(ctx context.Context, subscriptionEvents chan *subs
 			if err != nil {
 				log.WithError(err).Error("Failed to fetch consumer offsets")
 
+				m.scheduler.ticker.Reset(m.scheduler.shortenedInterval)
+
 				m.scheduler.failureCount++
-				if m.scheduler.failureCount >= m.scheduler.maxFailureCount {
-					log.Errorf("Fetching offsets failed %d times in a row. Consumer status data is stale.",
-						m.scheduler.failureCount)
-
-					m.clearConsumerStatus()
-
-					// It's necessary to restart the connection on broken pipe errors due to a
-					// bug in the Sarama library: https://github.com/Shopify/sarama/issues/1796
-					if errors.Is(err, syscall.EPIPE) {
-						log.Info("Attempting to re-establish monitoring connection...")
-
-						consumerFetcher, topicFetcher, err := newConsumerGroupOffsetFetchers(m.connectionString)
-						if err != nil {
-							log.WithError(err).Warn("Failed to establish new monitoring connection")
-						} else {
-							// Terminate the old connection and replace it.
-							_ = m.consumerOffsetFetcher.Close()
-
-							m.consumerOffsetFetcher = consumerFetcher
-							m.topicOffsetFetcher = topicFetcher
-
-							log.Info("Established new monitoring connection")
-						}
-					}
+				if m.scheduler.failureCount < m.scheduler.maxFailureCount {
+					continue
 				}
 
-				m.scheduler.ticker.Reset(m.scheduler.shortenedInterval)
-				continue
+				log.Errorf("Fetching offsets failed %d times in a row. Consumer status data is stale.",
+					m.scheduler.failureCount)
+
+				if !errors.Is(err, syscall.EPIPE) {
+					m.clearConsumerStatus()
+					continue
+				}
+
+				// It's necessary to restart the connection on broken pipe errors due to a
+				// bug in the Sarama library: https://github.com/Shopify/sarama/issues/1796
+				log.Info("Attempting to re-establish monitoring connection...")
+
+				consumerOffsetFetcher, topicOffsetFetcher, err := newConsumerGroupOffsetFetchers(m.connectionString)
+				if err != nil {
+					log.WithError(err).Warn("Failed to establish new monitoring connection")
+
+					m.clearConsumerStatus()
+					continue
+				}
+
+				// Terminate the old connection and replace it.
+				_ = m.consumerOffsetFetcher.Close()
+
+				m.consumerOffsetFetcher = consumerOffsetFetcher
+				m.topicOffsetFetcher = topicOffsetFetcher
+
+				log.Info("Established new monitoring connection")
+
+				// Re-attempt to fetch offsets and clear the status on failure.
+				offsets, err = m.fetchOffsets()
+				if err != nil {
+					log.WithError(err).Error("Failed to fetch consumer offsets after resetting the connection")
+
+					m.clearConsumerStatus()
+					continue
+				}
 			}
 
 			log.WithField("offsets", offsets).Debug("Offsets fetched successfully")


### PR DESCRIPTION
# Description

## What

The `sarama.ClusterAdmin` connection will break whenever Kafka brokers go through maintenance and are not available for a period of time. This is a [known issue](https://github.com/Shopify/sarama/issues/1796) in the library that has not been addressed yet.

## Why

[JIRA Ticket](https://financialtimes.atlassian.net/browse/UPPSF-3167)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
