### PR TITLE
Added constant for lag technical summary

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -22,6 +22,9 @@ const (
 	defaultConnectionRetryInterval = 1 * time.Minute
 )
 
+// LagTechnicalSummary is used as technical summary in consumer monitoring healthchecks.
+const LagTechnicalSummary string = "Messages awaiting handling exceed the configured lag tolerance. Check if Kafka consumer is stuck."
+
 // Consumer which will keep trying to reconnect to Kafka on a specified interval.
 // The underlying consumer group is created lazily when message listening is started.
 type Consumer struct {


### PR DESCRIPTION
# Description

Added a constant in the consumer file for other services as a technical summary when lag is present.

## What

Lag should not make a service appear unhealthy. When this constant is used in the technical summary of a health check of service that health check will be ignored even if failing.

## Why

[JIRA ticket](https://financialtimes.atlassian.net/browse/UPPSF-3283)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
